### PR TITLE
fix: replace imghdr (removed from Python 3.13) by puremagic

### DIFF
--- a/pngquant/main.py
+++ b/pngquant/main.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-import imghdr
+import puremagic
 import os
 import shutil
 import subprocess
@@ -338,7 +338,8 @@ class PngQuant(object):
             for name in files:
                 filename = os.path.join(root, name)
                 # Whether File An Image, If Not, Do Nothing
-                if imghdr.what(filename):
+                if puremagic
+                .what(filename):
                     # Compress Image By Call Function quant_image
                     # Dst Should Pass Dst + Name
                     ratio, data = self.quant_image(filename, dst=dst and os.path.join(dst, name), ndeep=ndeep, ndigits=ndigits, override=override, delete=delete)

--- a/pngquant/main.py
+++ b/pngquant/main.py
@@ -338,8 +338,7 @@ class PngQuant(object):
             for name in files:
                 filename = os.path.join(root, name)
                 # Whether File An Image, If Not, Do Nothing
-                if puremagic
-                .what(filename):
+                if puremagic.what(filename):
                     # Compress Image By Call Function quant_image
                     # Dst Should Pass Dst + Name
                     ratio, data = self.quant_image(filename, dst=dst and os.path.join(dst, name), ndeep=ndeep, ndigits=ndigits, override=override, delete=delete)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
 
     packages=['pngquant'],
     py_modules=[],
-    install_requires=['Pillow', ],
+    install_requires=['Pillow', 'puremagic', ],
 
     classifiers=[
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
`imghdr` is deprecated since Python 3.11 and removed from Python 3.13 (see [pep-0594](https://peps.python.org/pep-0594/#imghdr))
You should use `puremagic` instead